### PR TITLE
Remove network names from LP5

### DIFF
--- a/lp5/index.html
+++ b/lp5/index.html
@@ -240,7 +240,7 @@
 
             <div class="featured-section">
                 <h2>AS FEATURED IN</h2>
-                <img src="https://ext.same-assets.com/2099211216/711030526.webp" alt="Featured in Fox News, CBS, NBC News, USA Today" class="featured-logos">
+                <img src="https://ext.same-assets.com/2099211216/711030526.webp" alt="Featured in top media outlets" class="featured-logos">
             </div>
 
             <div class="references-section">


### PR DESCRIPTION
## Summary
- remove explicit Fox, CBS, NBC references from LP5 image alt text

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e755ab2b88330a641f986399d31fb